### PR TITLE
update downloadContamGenomes for more recent versions of wget

### DIFF
--- a/docker/Dockerfile.ppperljson
+++ b/docker/Dockerfile.ppperljson
@@ -3,7 +3,7 @@ FROM debian:buster
 LABEL maintainer="pricea35@cardiff.ac.uk" \
 software="perl container for json parsing"
 
-ENV PACKAGES="curl build-essential perl libjson-perl cpanminus jq"
+ENV PACKAGES="curl wget=1.20.1-1.1 build-essential perl libjson-perl cpanminus jq"
 
 RUN apt-get update && apt-get install -y $PACKAGES \
 && cpanm JSON::Create

--- a/modules/preprocessingModules.nf
+++ b/modules/preprocessingModules.nf
@@ -355,8 +355,6 @@ process preprocessing_downloadContamGenomes {
     * @QCcheckpoint confirm that we could download every genome in the list of contaminants
     */
     
-    executor 'local'
-
     tag { sample_name }
 
     publishDir "${params.output_dir}/$sample_name", mode: 'copy', pattern: '*.log'
@@ -376,8 +374,8 @@ process preprocessing_downloadContamGenomes {
     error_log = "${sample_name}.log"
 	
     """
-    wget -i $contam_list --spider -nv -a linktestlog.txt 2>&1
-    cat linktestlog.txt | awk '/fna.gz\" \\[1\\]/{print \$4}' > confirmedurllist.txt
+    wget -i ${contam_list} --spider -nv -a linktestlog.txt 2>&1
+    cat linktestlog.txt | awk '/listing\" \\[1\\]/{print \$4}' > confirmedurllist.txt
     wget -i confirmedurllist.txt
 
     gunzip *.gz

--- a/nextflow.config
+++ b/nextflow.config
@@ -86,6 +86,12 @@ profiles {
         container = "${params.sif_dir}/ppPerljson.sif"
       }
 
+      withName:preprocessing_downloadContamGenomes {
+        // disable strict error checking to allow for non-matching lines in linktestlog.txt
+        container = "${params.sif_dir}/ppPerljson.sif"
+        shell = ['/bin/bash','-u']
+      }
+
       withName:preprocessing_mapToContamFa {
         container = "${params.sif_dir}/ppBwa.sif"
       }
@@ -151,6 +157,12 @@ profiles {
 
       withName:preprocessing_identifyBacterialContaminants {
         container = "annacprice/ppperljson:latest"
+      }
+
+      withName:preprocessing_downloadContamGenomes {
+        // disable strict error checking to allow for non-matching lines in linktestlog.txt
+        container = "annacprice/ppperljson:latest"
+        shell = ['/bin/bash','-u']
       }
 
       withName:preprocessing_mapToContamFa {

--- a/singularity/Singularity.ppPerljson
+++ b/singularity/Singularity.ppPerljson
@@ -6,13 +6,13 @@ maintainer="pricea35@cardiff.ac.uk"
 software="perl container for json parsing" 
 
 %post
-PACKAGES="curl build-essential perl libjson-perl cpanminus jq"
+PACKAGES="curl wget=1.20.1-1.1 build-essential perl libjson-perl cpanminus jq"
 
 apt-get update && apt-get install -y $PACKAGES \
 && cpanm JSON::Create
 
 %environment
-export PACKAGES="curl build-essential perl libjson-perl cpanminus jq"
+export PACKAGES="curl wget=1.20.1-1.1 build-essential perl libjson-perl cpanminus jq"
 
 %runscript
 exec /bin/bash "$@"


### PR DESCRIPTION
preprocessing_downloadContamGenomes fails for recent versions of wget. The process has been updated for wget 1.20.1 and containerised with the version of wget pinned to ensure correct execution